### PR TITLE
Add support for kafka rc releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG scala_version=2.12
 ARG glibc_version=2.29-r0
 ARG vcs_ref=unspecified
 ARG build_date=unspecified
+ARG kafka_download_url=unspecified
 
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \
@@ -18,7 +19,8 @@ LABEL org.label-schema.name="kafka" \
 ENV KAFKA_VERSION=$kafka_version \
     SCALA_VERSION=$scala_version \
     KAFKA_HOME=/opt/kafka \
-    GLIBC_VERSION=$glibc_version
+    GLIBC_VERSION=$glibc_version \
+    KAFKA_DOWNLOAD_URL=$kafka_download_url
 
 ENV PATH=${PATH}:${KAFKA_HOME}/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ LABEL org.label-schema.name="kafka" \
 ENV KAFKA_VERSION=$kafka_version \
     SCALA_VERSION=$scala_version \
     KAFKA_HOME=/opt/kafka \
-    GLIBC_VERSION=$glibc_version \
     KAFKA_DOWNLOAD_URL=$kafka_download_url
-    KAFKA_HOME=/opt/kafka
 
 ENV PATH=${PATH}:${KAFKA_HOME}/bin
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ All versions of the image are built from the same set of scripts with only minor
 Everytime the image is updated, all tags will be pushed with the latest updates. This should allow for greater consistency across tags, as well as any security updates that have been made to the base image.
 
 ---
+## Building non released kafka docker images
+In order to build a non released kafka version docker image (eg.: rc releases), one can use the following build command:
+
+```
+docker build --build-arg kafka_version=2.4.0 --build-arg kafka_download_url=https://home.apache.org/\~manikumar/kafka-2.4.0-rc4/kafka_2.12-2.4.0.tgz -t kafka:2.4.0-rc4 .
+```
+
+---
 
 ## Announcements
 

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -2,16 +2,21 @@
 
 # shellcheck disable=SC1091
 source "/usr/bin/versions.sh"
-
 FILENAME="kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 
-url=$(curl --stderr /dev/null "https://www.apache.org/dyn/closer.cgi?path=/kafka/${KAFKA_VERSION}/${FILENAME}&as_json=1" | jq -r '"\(.preferred)\(.path_info)"')
+if [[ "$KAFKA_DOWNLOAD_URL" == "unspecified" ]]; then
 
-# Test to see if the suggested mirror has this version, currently pre 2.1.1 versions
-# do not appear to be actively mirrored. This may also be useful if closer.cgi is down.
-if [[ ! $(curl -s -f -I "${url}") ]]; then
-    echo "Mirror does not have desired version, downloading direct from Apache"
-    url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${FILENAME}"
+    url=$(curl --stderr /dev/null "https://www.apache.org/dyn/closer.cgi?path=/kafka/${KAFKA_VERSION}/${FILENAME}&as_json=1" | jq -r '"\(.preferred)\(.path_info)"')
+
+    # Test to see if the suggested mirror has this version, currently pre 2.1.1 versions
+    # do not appear to be actively mirrored. This may also be useful if closer.cgi is down.
+    if [[ ! $(curl -s -f -I "${url}") ]]; then
+        echo "Mirror does not have desired version, downloading direct from Apache"
+        url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${FILENAME}"
+    fi
+
+else
+    url=${KAFKA_DOWNLOAD_URL}
 fi
 
 echo "Downloading Kafka from $url"


### PR DESCRIPTION
Added the kafka_download_url ARG to docker file to support non standard releases. The rest of the params maintain their scope. Usage example: `docker build --build-arg kafka_version=2.4.0 --build-arg kafka_download_url=https://home.apache.org/\~manikumar/kafka-2.4.0-rc4/kafka_2.12-2.4.0.tgz .`